### PR TITLE
generate links like laravel pagination

### DIFF
--- a/src/Firestore/Eloquent/QueryHelpers/PaginateTrait.php
+++ b/src/Firestore/Eloquent/QueryHelpers/PaginateTrait.php
@@ -281,7 +281,7 @@ trait PaginateTrait
                 }
             }
 
-            public function laravelLinks()
+            public function inertiaLinks()
             {
                 
                 $maxLinks = $this->pagination->per_page;

--- a/src/Firestore/Eloquent/QueryHelpers/PaginateTrait.php
+++ b/src/Firestore/Eloquent/QueryHelpers/PaginateTrait.php
@@ -281,6 +281,45 @@ trait PaginateTrait
                 }
             }
 
+            public function laravelLinks()
+            {
+                
+                $maxLinks = $this->pagination->per_page;
+                $links = [];
+                $totalPages = $this->pagination->total_pages;
+                $currentPage = $this->pagination->current_page;
+                $startPage = max(1, $currentPage - intval($maxLinks / 2));
+                $endPage = min($totalPages, $startPage + $maxLinks - 1);
+            
+                // Adjust the start page if we're close to the end
+                $startPage = max(1, min($startPage, $totalPages - $maxLinks + 1));
+            
+                // Previous Page Link
+                $links[] = [
+                    'url' => $currentPage > 1 ? $this->previousPageUrl() : null,
+                    'label' => '&laquo; Previous',
+                    'active' => false
+                ];
+            
+                // Generate Page Number Links
+                for ($page = $startPage; $page <= $endPage; $page++) {
+                    $links[] = [
+                        'url' => $this->url($page),
+                        'label' => (string) $page,
+                        'active' => $page == $currentPage
+                    ];
+                }
+            
+                // Next Page Link
+                $links[] = [
+                    'url' => $currentPage < $totalPages ? $this->nextPageUrl() : null,
+                    'label' => 'Next &raquo;',
+                    'active' => false
+                ];
+            
+                return $links;
+            }
+
             /* public function livewireLinks($theme = null)
             {
                 if($this->hasMorePages() || $this->totalPages() > 1){


### PR DESCRIPTION
So because the 'links' method returns an html template, it would not be viable to work for inertiajs. This is because with inertiajs it will make a full page refresh. So i have made a method that will return the links in this format

```
 [
                {
                    "url": null,
                    "label": "&laquo; Previous",
                    "active": false
                },
                {
                    "url": "http:\/\/127.0.0.1:8000\/events?page=1",
                    "label": "1",
                    "active": true
                },
                {
                    "url": "http:\/\/127.0.0.1:8000\/events?page=2",
                    "label": "2",
                    "active": false
                },
                {
                    "url": "http:\/\/127.0.0.1:8000\/events?page=2",
                    "label": "Next &raquo;",
                    "active": false
                }
            ]
```
In this format one is able to make his own UI with ease. And best of all it doesn't cause a full page refresh on inertiajs when i navigate to another page